### PR TITLE
Bump pygments to 2.20.0 in develop group

### DIFF
--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -1735,11 +1735,11 @@
         },
         "pygments": {
             "hashes": [
-                "sha256:636cb2477cec7f8952536970bc533bc43743542f70392ae026374600add5b887",
-                "sha256:86540386c03d588bb81d44bc3928634ff26449851e99741617ecb9037ee5ec0b"
+                "sha256:6757cd03768053ff99f3039c1a36d6c0aa0b263438fcab17520b30a303a82b5f",
+                "sha256:81a9e26dd42fd28a23a2d169d86d7ac03b46e2f8b59ed4698fb4785f946d0176"
             ],
-            "markers": "python_version >= '3.8'",
-            "version": "==2.19.2"
+            "markers": "python_version >= '3.9'",
+            "version": "==2.20.0"
         },
         "pytokens": {
             "hashes": [


### PR DESCRIPTION
Resolves the last open Dependabot alert, [#43](https://github.com/RamVasuthevan/ontario-marriage-officiants/security/dependabot/43) (GHSA-5239-wwwm-4pmq, low severity — ReDoS in Pygments' GUID-matching regex, patched in 2.20.0).

The `default` group in `Pipfile.lock` was already on 2.20.0 (via #34), but the `develop` group still pinned 2.19.2. This copies the same 2.20.0 pin and hashes into the develop group so both resolve to the patched version.

🤖 Generated with [Claude Code](https://claude.com/claude-code)